### PR TITLE
Add AI assistant instruction guides

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,37 @@
+# Codex Assistant Instructions
+
+This file governs how OpenAI Codex (and related command-line helpers that leverage the Codex API)
+should interact with repositories derived from `scotlaclair.github.io`.
+
+## Scope
+
+- Applies to automation or scripting stored in `.codex/`.
+- Covers developer workflows that invoke the `openai` CLI or editor integrations backed by Codex.
+
+## Operating Principles
+
+1. **Reference Canonical Docs** – Ground answers in `README.md`, `.github/*.md`, and
+   `docs/ai-dev-environment-setup.md`.
+2. **Promote Testing** – When proposing code, instruct contributors to run relevant tests or site
+   build steps before committing.
+3. **Call Out Secrets** – Remind users to configure `OPENAI_API_KEY` via environment variables or
+   secret managers. Never hard-code credentials.
+4. **Document Prompt Engineering** – Encourage saving effective prompts in `docs/ai-dev-environment-setup.md`
+   or a follow-up issue so the template community benefits.
+
+## Writing Style
+
+- Use concise, task-focused language.
+- Prefer numbered procedures and shell-friendly snippets.
+- Mention when a step is optional or template-specific.
+
+## Integration Tips
+
+- Pair Codex-generated code with manual review and ensure the repository's pull request template is
+  followed.
+- Suggest enabling audit logging in the OpenAI dashboard for teams that require compliance tracking.
+- When editing workflows or configs, highlight which values may differ across downstream template
+  consumers.
+
+Following these instructions keeps Codex-driven contributions aligned with the repository's
+standards and governance model.

--- a/.codex/Codex.md
+++ b/.codex/Codex.md
@@ -1,0 +1,56 @@
+# Codex CLI & Workflow Guide
+
+Use this reference to integrate OpenAI Codex with projects based on the
+`scotlaclair.github.io` template.
+
+## 1. Install & Authenticate
+
+1. Install the OpenAI CLI (requires Python 3.11+):
+   ```bash
+   pip install openai
+   ```
+2. Export your API key (store in 1Password, `pass`, or your preferred secret manager):
+   ```bash
+   export OPENAI_API_KEY="$(pass show ai/openai)"
+   ```
+3. (Optional) Configure a default organization or project:
+   ```bash
+   export OPENAI_ORG="org_123"
+   ```
+
+## 2. Helpful Commands
+
+- **Chat about repository context**
+  ```bash
+  openai chat.completions.create \
+    -m gpt-4.1-mini \
+    -p "Summarize the setup tasks in .github/SETUP_GUIDE.md"
+  ```
+- **Generate code suggestions for a file**
+  ```bash
+  openai responses.create \
+    -m gpt-4.1-mini \
+    -i @path/to/file.py \
+    -p "Add unit tests following the repository's conventions."
+  ```
+- **Review a diff**
+  ```bash
+  git diff > /tmp/changes.diff
+  openai responses.create -m gpt-4o-mini -f /tmp/changes.diff -p "Review this diff for issues."
+  ```
+
+## 3. Best Practices
+
+- Track AI-assisted commits in pull request summaries as required by
+  `.github/PULL_REQUEST_TEMPLATE.md`.
+- Run project checks (linting, site preview) after applying Codex output.
+- Update `docs/ai-dev-environment-setup.md` with new workflows or prompt recipes that work well.
+
+## 4. Troubleshooting
+
+- **401 Unauthorized** – Confirm `OPENAI_API_KEY` is exported in the current shell.
+- **Timeouts** – Reduce prompt size or stream responses using the SDK for long-running tasks.
+- **Rate Limits** – Use the OpenAI dashboard to request higher limits or stagger automation.
+
+Codex can accelerate template customization when paired with the governance and automation already
+present in this repository.

--- a/.gemini/AGENTS.md
+++ b/.gemini/AGENTS.md
@@ -1,0 +1,34 @@
+# Gemini Tooling Instructions
+
+These instructions cover all files within the `.gemini/` directory and any workflows that
+reference the Gemini CLI for this repository.
+
+## Purpose
+
+Document how contributors should configure and use Google Gemini Code Assist/CLI when working from
+this template repository.
+
+## Key References
+
+- `Gemini.md`: Primary quick-start guide for enabling the Gemini CLI.
+- `config.yaml`: Shared configuration for Gemini CLI defaults (model, temperature, output format).
+
+## Contribution Expectations
+
+- Keep configuration declarative. Prefer YAML/JSON updates in `config.yaml` over inline CLI flags
+  within docs.
+- Record any required environment variables or secrets in `Gemini.md` so downstream templates can
+  copy the instructions verbatim.
+- Document testing or validation commands (e.g., `gemini code test`, `gemini code review`) whenever
+  changes to automation or prompts are suggested.
+- Preserve vendor-neutral language where possible and call out steps that are Gemini-specific so
+  other AI assistants can find alternative paths.
+
+## Style Guidance
+
+- Use actionable headings and checklists.
+- Favor short paragraphs and bullet lists for readability.
+- Link back to `docs/ai-dev-environment-setup.md` for broader AI onboarding context.
+
+By following these guidelines, contributors maintain a consistent AI integration experience across
+repositories derived from this template.

--- a/.gemini/Gemini.md
+++ b/.gemini/Gemini.md
@@ -1,0 +1,53 @@
+# Gemini CLI Quick Start
+
+Use this guide to configure the Google Gemini CLI for repositories cloned from the
+`scotlaclair.github.io` template.
+
+## 1. Prerequisites
+
+- Google Cloud project with the Gemini Code Assist API enabled.
+- `gcloud` CLI installed and authenticated (`gcloud auth login`).
+- Gemini CLI installed (`pip install google-genai` or follow
+  [official instructions](https://ai.google.dev/gemini-api/docs)).
+- API key stored as `GEMINI_API_KEY` in your environment or secret manager.
+
+## 2. Configure the CLI
+
+1. Copy `.gemini/config.yaml` into your user configuration directory if you want to share defaults:
+   ```bash
+   mkdir -p ~/.config/gemini
+   cp .gemini/config.yaml ~/.config/gemini/config.yaml
+   ```
+2. Update the copied config to reference your preferred model (for example `gemini-1.5-pro`) and
+   adjust temperature/output formats as needed.
+3. Export your API key before running commands:
+   ```bash
+   export GEMINI_API_KEY="$(pass show ai/gemini)"
+   ```
+
+## 3. Common Commands
+
+- **Ask a question about the repo**
+  ```bash
+  gemini chat --context README.md --message "Summarize the setup guides provided in .github/."
+  ```
+- **Review a diff**
+  ```bash
+  gemini code review --diff <(git diff)
+  ```
+- **Generate tests for a file**
+  ```bash
+  gemini code test --file path/to/file.py
+  ```
+
+Each command respects the defaults stored in `.gemini/config.yaml`. Override flags per run if you
+need a different model or output format.
+
+## 4. Collaboration Tips
+
+- Mention when Gemini assisted with a change in your pull request description.
+- Pair Gemini suggestions with manual verification (run project tests or preview the Pages site).
+- Capture useful prompts in `docs/ai-dev-environment-setup.md` so the template stays current.
+
+With this quick start in place, teams using the template can enable Gemini support with minimal
+setup.

--- a/.github/TEMPLATE_REPO_GUIDE.md
+++ b/.github/TEMPLATE_REPO_GUIDE.md
@@ -1,0 +1,70 @@
+# Template Repository Configuration Guide
+
+This guide captures the reusable configuration from `scotlaclair.github.io` so you can stand up
+new repositories with the same community and workflow foundations. Use it as a checklist when
+turning this repository into a template or when porting the setup to other projects.
+
+---
+
+## 1. Repository Settings
+
+- **Template Repository**: From the repository settings, enable “Template repository” so others can
+  create new projects pre-populated with these files.
+- **Default Branch Protection**: Require pull request reviews, status checks, and linear history to
+  keep contributions consistent.
+- **Pages Configuration**: If the new repo should publish through GitHub Pages, decide whether the
+  root or `/docs` directory should be served and ensure an `index.html` (or equivalent) exists.
+
+## 2. Community Health Files
+
+All of the following files reside in the root or `.github/` directory:
+
+| Purpose | Location | Notes |
+| --- | --- | --- |
+| Code of Conduct | `CODE_OF_CONDUCT.md` | Reference in new repository settings so GitHub auto-detects it. |
+| Contributing Guide | `CONTRIBUTING.md` | Update project-specific contribution paths and expectations. |
+| Security Policy | `SECURITY.md` | Adjust contact address or disclosure window if needed. |
+| Pull Request Template | `.github/PULL_REQUEST_TEMPLATE.md` | Provides consistent change summaries and testing notes. |
+| Issue Templates | `.github/ISSUE_TEMPLATE/` | Includes spark, bug, documentation, feature, and setup sub-issue templates. |
+| Discussion Templates | `.github/DISCUSSION_TEMPLATE/` and `.github/discussions.yml` | Pre-configures Ideas, Questions, and Show & Tell topics. |
+| Labels Definition | `.github/labels.yml` | Import via GitHub CLI or automation to standardize labels. |
+
+## 3. Knowledge Base & Documentation
+
+- **Docs Site**: The `docs/` directory functions as the knowledge base and mirrors the published site.
+  When cloning to a new repo, review internal links for project-specific paths.
+- **Guides Library**: `.github/` contains focused guides (setup, workflows, wiki, discussions, optional
+  additions). Keep them when you want the same operating model, or prune as needed for simpler repos.
+- **Homepage Assets**: `index.html`, `assets/`, `robots.txt`, `sitemap.xml`, and `404.html` create a
+  basic but complete web presence. Decide if each new repo needs its own site or should defer to a
+  central hub.
+
+## 4. Automation & Workflows
+
+- **GitHub Actions**: `.github/workflows/` contains reusable automation for Pages deployments,
+  labeling, and maintenance. Confirm the triggers make sense for the new project before enabling.
+- **Checklists & Summaries**: `.github/CHECKLIST_AUTOMATION_SUMMARY.md` and related files document how
+  automation ties into issue and PR hygiene. Update references to match the new repository’s goals.
+
+## 5. Optional Setup Tasks
+
+Use `.github/OPTIONAL_ADDITIONS_GUIDE.md` and `.github/SETUP_GUIDE.md` as comprehensive references
+for optional features such as custom domains, sitemap management, and spark workflows. When creating
+a template, these guides help contributors understand which pieces to keep or adapt.
+
+## 6. Getting Started Workflow
+
+1. **Create from Template**: Use the “Use this template” button (or `gh repo create --template`).
+2. **Review Branding**: Update names, logos, and copy in `index.html`, `docs/`, and `README.md`.
+3. **Audit Links**: Fix repository-specific links (issues, discussions, wiki) so they point to the
+   new repo.
+4. **Set Up Automation**: Enable Actions and, if necessary, update secrets or environment variables.
+5. **Confirm Publishing**: If using Pages, configure the branch/folder and verify the site builds.
+6. **Publish Setup Tasks**: Create parent issues using the provided templates to track onboarding
+   progress for the new repository.
+
+---
+
+By following this checklist, every repository created from the template will launch with a consistent
+community experience, documentation hub, and automation suite, reducing setup time and ensuring best
+practices are in place from day one.

--- a/.github/copilot/chat/agent/path/AGENTS.md
+++ b/.github/copilot/chat/agent/path/AGENTS.md
@@ -1,0 +1,47 @@
+# Copilot Chat Agent Instructions
+
+These instructions apply to any GitHub Copilot Chat sessions or Agents that operate within
+`.github/copilot/chat/agent/path/` or interact with repository content on behalf of contributors.
+
+## Purpose
+
+Provide Copilot Chat with the project context it needs to produce accurate answers and proposed
+patches when working in this template-style repository.
+
+## Response Expectations
+
+- Summaries must reference authoritative documentation inside the repo, especially the guides in
+  `.github/` and `docs/`.
+- When Copilot suggests code or configuration changes, it should also mention the relevant testing
+  steps (`npm test`, `bundle exec`, etc.) or explicitly state when no automated test exists.
+- Prefer incremental diffs over full-file rewrites unless structural changes are required.
+- Encourage contributors to capture follow-up tasks in GitHub Issues if scope expands.
+
+## Repository Orientation
+
+- The `README.md` contains quick links to the documentation, setup, and automation guides.
+- `.github/TEMPLATE_REPO_GUIDE.md` explains how to reuse this repository as a template and is the
+  canonical source for community configuration.
+- `docs/ai-dev-environment-setup.md` and the new Gemini/Codex notes capture AI-specific onboarding
+  steps; Copilot Chat responses should link to them when applicable.
+- Automation workflows and labels live in `.github/workflows/` and `.github/labels.yml`.
+
+## Interaction Guidelines
+
+1. **Maintain Attribution** – Call out when code snippets are AI-generated and encourage human
+   review before merging.
+2. **Respect Style** – Match the existing Markdown voice (instructional, actionable, concise).
+3. **Surface Checks** – Remind users to run linting and site build validations when editing Pages
+   content or workflows.
+4. **Template Awareness** – Highlight which instructions are template defaults versus
+   repository-specific customizations so downstream repos can adjust accordingly.
+
+## Suggested Prompts for Users
+
+- "Summarize the onboarding steps from `.github/SETUP_GUIDE.md`."
+- "Draft a pull request description that follows `.github/PULL_REQUEST_TEMPLATE.md`."
+- "Outline the workflow updates needed to enable GitHub Pages deployments for a new repo based on
+  this template."
+
+By following these instructions, Copilot Chat stays aligned with the repository's governance while
+accelerating contributor support.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Repo for Pages and Documents, new sparks
 - 💡 **Submit a Spark**: [New Idea](../../issues/new?template=spark.yml)
 - 🐛 **Report a Bug**: [Bug Report](../../issues/new?template=bug.yml)
 - 📝 **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md)
+- 🧩 **Template Setup**: See [.github/TEMPLATE_REPO_GUIDE.md](.github/TEMPLATE_REPO_GUIDE.md)
+- 🤖 **AI Assistant Setup**: See [docs/ai-dev-environment-setup.md](docs/ai-dev-environment-setup.md)
 - ⚙️ **Setup Guide**: See [.github/SETUP_GUIDE.md](.github/SETUP_GUIDE.md)
 - 🔗 **PR Linking Guide**: See [.github/PR_ISSUE_LINKING_REFERENCE.md](.github/PR_ISSUE_LINKING_REFERENCE.md)
 

--- a/docs/ai-dev-environment-setup.md
+++ b/docs/ai-dev-environment-setup.md
@@ -79,6 +79,15 @@ Create a checklist issue template for new contributors including:
 - Encourage contributors to log AI feedback in a dedicated GitHub Discussion or Project view.
 - Iterate on templates and workflows as best practices evolve.
 
+## 9. Tool-Specific Quick Starts
+
+- **GitHub Copilot Chat** – Follow the instructions in `.github/copilot/chat/agent/path/AGENTS.md`
+  when configuring agents or sharing prompt libraries.
+- **Google Gemini CLI** – Use `.gemini/Gemini.md` alongside `.gemini/config.yaml` for installation
+  and command examples tailored to this template.
+- **OpenAI Codex** – Reference `.codex/Codex.md` and `.codex/AGENTS.md` for CLI setup, prompt
+  recipes, and governance reminders.
+
 ---
 
 With this foundation in place, you can create new repositories from the template and immediately benefit from consistent automation, governance, and AI-assisted development workflows.


### PR DESCRIPTION
## Summary
- add Copilot Chat agent instructions under `.github/copilot/chat/agent/path`
- provide Gemini CLI quick start docs and directory guidance
- document Codex CLI usage and reference the new AI guides from the broader onboarding docs

## Testing
- not run (docs-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e880d39448832c83f062fdf4f34eef